### PR TITLE
Support configurable endpoints via Phoenix Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,14 +157,27 @@ Configure the MCP router in your Phoenix endpoint or Plug pipeline:
 Use the `MCP.Router` module with `forward` to mount the MCP router at a specific path:
 
 ```elixir
-# In your Phoenix endpoint or main router
-defmodule MyAppWeb.Endpoint do
-  use Phoenix.Endpoint, otp_app: :my_app
+# In your config.exs
+config :mime, :types, %{
+  "text/event-stream" => ["sse"]
+}
 
-  # Forward MCP requests to the MCP.Plug module
-  forward "/mcp/sse", MCP.Router, init_callback: &MyApp.MCPTools.init_callback/2
+# In your Phoenix router
+defmodule MyAppWeb.Router do
+  use MyAppWeb, :router
+
+  pipeline :mcp_sse do
+    plug accepts: ["sse"]
+  end
+
+  # Forward MCP requests to the MCP.Router
+  scope "/mcp/sse" do
+    pipe_through :mcp_sse
+    
+    forward "/", MCP.Router, init_callback: &MyApp.MCPTools.init_callback/2
+  end
   
-  # Your other plugs...
+  # Your other routes...
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,19 +152,41 @@ end
 
 Configure the MCP router in your Phoenix endpoint or Plug pipeline:
 
+#### Option 1: Using forward 
+
+Use the `MCP.Router` module with `forward` to mount the MCP router at a specific path:
+
+```elixir
+# In your Phoenix endpoint or main router
+defmodule MyAppWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :my_app
+
+  # Forward MCP requests to the MCP.Plug module
+  forward "/mcp/sse", MCP.Router, init_callback: &MyApp.MCPTools.init_callback/2
+  
+  # Your other plugs...
+end
+```
+
+This makes the MCP router available at:
+- `GET /mcp/sse` - Establishes an SSE connection
+- `POST /mcp/sse/message` - Receives JSON-RPC messages
+
+#### Option 2: Direct plug usage
+
 ```elixir
 # In your Phoenix endpoint
 defmodule MyAppWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :my_app
 
-  # Add the MCP router
+  # Add the MCP router directly
   plug MCP.Router, init_callback: &MyApp.MCPTools.init_callback/2
   
   # Your other plugs...
 end
 ```
 
-Or use it standalone with Bandit:
+#### Option 3: Standalone with Bandit
 
 ```elixir
 # In your application.ex

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -65,7 +65,7 @@ defmodule MCP.Connection do
   @doc """
   Checks if a connection is ready to receive MCP requests.
 
-  A connection is considered ready after the client has sent both the `initialize` 
+  A connection is considered ready after the client has sent both the `initialize`
   request and the `notifications/initialized` notification.
 
   ## Parameters
@@ -422,8 +422,6 @@ defmodule MCP.Connection do
     case resp do
       {:noreply, state} ->
         halt(state.conn)
-        {:stop, reason, state}
-        {:stop, reason, state}
         {:stop, reason, state}
     end
   end

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -45,6 +45,8 @@ defmodule MCP.Connection do
     # Start inactivity timeout
     timeout_ref = Process.send_after(self(), :inactivity_timeout, @inactivity_timeout)
 
+    Logger.info("Opening SSE Connection")
+
     :gen_server.enter_loop(__MODULE__, [], %{
       session_id: session_id,
       conn: conn,
@@ -420,6 +422,10 @@ defmodule MCP.Connection do
       |> handle_sse_response(state, "close")
 
     case resp do
+      {:stop, reason, state} ->
+        halt(state.conn)
+        {:stop, reason, state}
+
       {:noreply, state} ->
         halt(state.conn)
         {:stop, reason, state}

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -360,8 +360,9 @@ defmodule MCP.Connection do
     end
   end
 
-  defp schedule_next_ping(%{sse_keepalive_timeout: timeout}) do
+  defp schedule_next_ping(%{sse_keepalive_timeout: timeout} = state) do
     Process.send_after(self(), :send_ping, timeout)
+    state
   end
 
   defp record_activity(state) do

--- a/lib/sse.ex
+++ b/lib/sse.ex
@@ -83,7 +83,7 @@ defmodule MCP.SSE do
   end
 
   defp send_initial_message(conn, session_id) do
-    path = Path.join(conn.path_info ++ ["message"])
+    path = Path.join([conn.request_path, "message"])
 
     endpoint =
       "#{conn.scheme}://#{conn.host}:#{conn.port}/#{path}?sessionId=#{session_id}"


### PR DESCRIPTION
This addresses a few bugs I discovered in my attempts to add support for exposing the `MCP.Router` via a Phoenix Router pipeline at a specific prefix. 